### PR TITLE
Fix potential breakWordHard StringIndexOutOfBoundsException

### DIFF
--- a/src/main/java/rst/pdfbox/layout/util/WordBreakers.java
+++ b/src/main/java/rst/pdfbox/layout/util/WordBreakers.java
@@ -97,6 +97,9 @@ public class WordBreakers {
 	    } else if (currentWidth < maxWidth) {
 		while (currentWidth < maxWidth) {
 		    ++cutIndex;
+		    if (cutIndex > word.length()) {
+		    	break;
+		    }
 		    currentWidth = getStringWidth(word.substring(0, cutIndex),
 			    fontDescriptor);
 		}


### PR DESCRIPTION
This is a small fix for a potential `StringIndexOutOfBoundsException` that can happen if `cutIndex` is increased to be greater than `word.length()` e.g. via

`breakWordHard("sometext-0000-0000", new FontDescriptor(PDType1Font.HELVETICA, 10), 92.65513f)`

Thanks